### PR TITLE
[M3-Fix] Edit Mode

### DIFF
--- a/core/presentation/src/main/java/com/icdid/core/presentation/theme/Color.kt
+++ b/core/presentation/src/main/java/com/icdid/core/presentation/theme/Color.kt
@@ -28,7 +28,7 @@ val fabBackground = Brush.verticalGradient(
 )
 
 // region dark mode
-val darkPrimary = Color(0xFF8DAEFF)
+val darkPrimary = Color(0xFF476FC9)
 val darkOnPrimary = Color(0xFF000000)
 val darkSurface = Color(0xFF121212)
 val darkOnSurface = Color(0xFFEAEAEA)

--- a/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/note_detail/NoteDetailLanscapeView.kt
+++ b/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/note_detail/NoteDetailLanscapeView.kt
@@ -29,7 +29,7 @@ import com.icdid.core.presentation.utils.TabletLandscape
 import com.icdid.core.presentation.utils.UiText
 import com.icdid.dashboard.presentation.R
 import com.icdid.dashboard.presentation.note_detail.composables.NavigationButton
-import com.icdid.dashboard.presentation.note_detail.composables.NoteFormView
+import com.icdid.dashboard.presentation.note_detail.composables.NoteEditMode
 import com.icdid.dashboard.presentation.note_detail.composables.NoteViewMode
 import com.icdid.dashboard.presentation.note_detail.model.NoteDetailMode
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -44,7 +44,7 @@ fun NoteDetailLandscapeView(
     val spaceArrangement = when (state.noteMode) {
         NoteDetailMode.VIEW -> 12.dp
         NoteDetailMode.EDIT -> 70.dp
-        NoteDetailMode.READ -> 12.dp // TODO: Check again for read UI
+        NoteDetailMode.READ -> 12.dp
     }
 
     val scrollState = rememberScrollState()
@@ -127,7 +127,7 @@ fun NoteDetailLandscapeView(
                     }
                 )
 
-                NoteFormView(
+                NoteEditMode(
                     modifier = Modifier
                         .weight(1f)
                         .imePadding(),

--- a/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/note_detail/NoteDetailPortraitView.kt
+++ b/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/note_detail/NoteDetailPortraitView.kt
@@ -22,7 +22,7 @@ import com.icdid.core.presentation.utils.TabletPortrait
 import com.icdid.core.presentation.utils.UiText
 import com.icdid.dashboard.presentation.R
 import com.icdid.dashboard.presentation.note_detail.composables.NavigationButton
-import com.icdid.dashboard.presentation.note_detail.composables.NoteFormView
+import com.icdid.dashboard.presentation.note_detail.composables.NoteEditMode
 import com.icdid.dashboard.presentation.note_detail.composables.NoteViewMode
 import com.icdid.dashboard.presentation.note_detail.model.NoteDetailMode
 
@@ -108,7 +108,7 @@ fun NoteDetailPortraitView(
             }
 
             NoteDetailMode.EDIT -> {
-                NoteFormView(
+                NoteEditMode(
                     isTablet = isTablet,
                     state = state,
                     onAction = onAction,

--- a/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/note_detail/NoteDetailViewModel.kt
+++ b/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/note_detail/NoteDetailViewModel.kt
@@ -74,26 +74,8 @@ class NoteDetailViewModel(
             is NoteDetailAction.OnConfirmationDialogDismissed -> dismissDialog()
             is NoteDetailAction.OnConfirmationDialogConfirmed -> confirmDiscardChanges()
             is NoteDetailAction.OnChangeMode -> changeMode(action.detailMode)
-            NoteDetailAction.OnReadModeTap -> {
-                if (!_state.value.areUiElementsVisible) {
-                    startCountdown()
-                } else {
-                    stopCountdown()
-                }
-                _state.update { currentState ->
-                    currentState.copy(
-                        areUiElementsVisible = !currentState.areUiElementsVisible
-                    )
-                }
-            }
-
-            NoteDetailAction.OnScrollStarted -> {
-                _state.update { currentState ->
-                    currentState.copy(
-                        areUiElementsVisible = false,
-                    )
-                }
-            }
+            NoteDetailAction.OnReadModeTap -> onReadModeTap()
+            NoteDetailAction.OnScrollStarted -> onScrollStarted()
         }
     }
 
@@ -193,11 +175,35 @@ class NoteDetailViewModel(
 
     private fun changeMode(mode: NoteDetailMode) {
         savedStateHandle[NOTE_MODE_KEY] = mode.name
-        stopCountdown()
+        if(mode == NoteDetailMode.READ) {
+            startCountdown()
+        } else {
+            stopCountdown()
+        }
         _state.update {
             it.copy(
                 noteMode = mode,
-                areUiElementsVisible = mode != NoteDetailMode.READ
+            )
+        }
+    }
+
+    private fun onReadModeTap() {
+        if (!_state.value.areUiElementsVisible) {
+            startCountdown()
+        } else {
+            stopCountdown()
+        }
+        _state.update { currentState ->
+            currentState.copy(
+                areUiElementsVisible = !currentState.areUiElementsVisible
+            )
+        }
+    }
+
+    private fun onScrollStarted() {
+        _state.update { currentState ->
+            currentState.copy(
+                areUiElementsVisible = false,
             )
         }
     }

--- a/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/note_detail/composables/NoteViewMode.kt
+++ b/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/note_detail/composables/NoteViewMode.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -43,7 +44,11 @@ fun NoteViewMode(
                 .padding(start = 16.dp)
         )
 
-        HorizontalDivider()
+        HorizontalDivider(
+            modifier = Modifier
+                .padding(bottom = 4.dp),
+            color = MaterialTheme.colorScheme.surface,
+        )
 
         Box(
             modifier = Modifier
@@ -87,7 +92,11 @@ fun NoteViewMode(
             }
         }
 
-        HorizontalDivider()
+        HorizontalDivider(
+            modifier = Modifier
+                .padding(top = 4.dp),
+            color = MaterialTheme.colorScheme.surface,
+        )
 
         Text(
             text = state.content,

--- a/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/settings/SettingsScreen.kt
+++ b/dashboard/presentation/src/main/java/com/icdid/dashboard/presentation/settings/SettingsScreen.kt
@@ -4,11 +4,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
@@ -16,7 +14,6 @@ import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable

--- a/dashboard/presentation/src/main/res/values/strings.xml
+++ b/dashboard/presentation/src/main/res/values/strings.xml
@@ -24,5 +24,5 @@
     <string name="all_notes">All Notes</string>
     <string name="date_created">Date Created</string>
     <string name="last_edited">Last edited</string>
-    <string name="just_now">Just Now\n</string>
+    <string name="just_now">Just Now</string>
 </resources>


### PR DESCRIPTION
In this PR:

- Fix primary color in dark mode
- Fix color and padding for the horizontal dividers in edit mode screen
- Fix text Just now is edit mode screen
- Some note detail view model refactor
- Not to hide ui element when read mode clicked and wait 5 seconds
- Fix setting screen container color to match the figma
- Fix when loading state in login then change email or password the button become enable again

Fix the issue in edit mode

- When enter edit mode it should focus in the note title
- When tap at the note content, the scroll should consider the keyboard space

![Jul-11-2025 16-29-44](https://github.com/user-attachments/assets/b4be19a3-1539-4639-a53b-9693d074d291)
